### PR TITLE
Content search: e621 tags and hashtags

### DIFF
--- a/src/lib/api/bluesky.ts
+++ b/src/lib/api/bluesky.ts
@@ -79,6 +79,77 @@ export async function getProfile(agent: BskyAgent, handle: string): Promise<Prof
 	};
 }
 
+/**
+ * Map an AT Protocol post view (from getAuthorFeed, getPosts, searchPosts, etc.)
+ * into our PhotoPost shape. Returns null if the post has no image embed or is
+ * hidden from logged-out viewers.
+ */
+export function postViewToPhotoPost(
+	post: any,
+	isRepost: boolean,
+	isAuthenticated: boolean
+): PhotoPost | null {
+	const embed = post.embed;
+
+	// Skip posts from authors who require authentication
+	if (!isAuthenticated && Array.isArray(post.author?.labels)) {
+		if (post.author.labels.some((l: any) => l.val === '!no-unauthenticated')) {
+			return null;
+		}
+	}
+
+	// Extract content labels
+	const labels: string[] = [];
+	if (post.labels && Array.isArray(post.labels)) {
+		for (const label of post.labels) {
+			if (label.val) labels.push(label.val);
+		}
+	}
+
+	const images: PhotoImage[] = [];
+	const recordCids = extractImageCids(post.record);
+
+	const pushImages = (imgs: any[]) => {
+		imgs.forEach((img: any, idx: number) => {
+			images.push({
+				cid: recordCids[idx] ?? '',
+				thumb: img.thumb,
+				fullsize: img.fullsize,
+				alt: img.alt || '',
+				aspectRatio: img.aspectRatio
+			});
+		});
+	};
+
+	if (embed?.$type === 'app.bsky.embed.images#view') {
+		pushImages(embed.images);
+	} else if (embed?.$type === 'app.bsky.embed.recordWithMedia#view') {
+		const media = embed.media;
+		if (media?.$type === 'app.bsky.embed.images#view') {
+			pushImages(media.images);
+		}
+	}
+
+	if (images.length === 0) return null;
+
+	return {
+		uri: post.uri,
+		cid: post.cid,
+		author: {
+			did: post.author.did,
+			handle: post.author.handle,
+			displayName: post.author.displayName,
+			avatar: post.author.avatar
+		},
+		images,
+		indexedAt: post.indexedAt,
+		parentChain: [],
+		isRepost,
+		labels,
+		nsfw: isNsfw(labels)
+	};
+}
+
 export async function getPhotoPosts(
 	agent: BskyAgent,
 	handle: string,
@@ -96,73 +167,63 @@ export async function getPhotoPosts(
 	const posts: PhotoPost[] = [];
 
 	for (const item of res.data.feed) {
-		const post = item.post;
-		const embed = post.embed;
 		const isRepost = item.reason?.$type === 'app.bsky.feed.defs#reasonRepost';
+		const mapped = postViewToPhotoPost(item.post, isRepost, isAuthenticated);
+		if (mapped) posts.push(mapped);
+	}
 
-		// Skip posts from authors who require authentication
-		if (!isAuthenticated && Array.isArray(post.author.labels)) {
-			if (post.author.labels.some((l: any) => l.val === '!no-unauthenticated')) {
-				continue;
-			}
-		}
+	return { posts, cursor: res.data.cursor };
+}
 
-		// Extract content labels
-		const labels: string[] = [];
-		if (post.labels && Array.isArray(post.labels)) {
-			for (const label of post.labels) {
-				if (label.val) labels.push(label.val);
-			}
-		}
+/**
+ * Hydrate an ordered list of at:// post URIs into PhotoPosts. Used to render
+ * entail tag-search matches (which only carry uri+cid) in the Mosaic. Batches
+ * into the 25-uri limit of app.bsky.feed.getPosts and preserves input order.
+ */
+export async function getPhotoPostsByUris(agent: BskyAgent, uris: string[]): Promise<PhotoPost[]> {
+	const isAuthenticated = !!agent.session;
+	const unique = [...new Set(uris)];
+	const byUri = new Map<string, PhotoPost>();
 
-		const images: PhotoImage[] = [];
-		const recordCids = extractImageCids((post as any).record);
-
-		if (embed?.$type === 'app.bsky.embed.images#view') {
-			(embed as any).images.forEach((img: any, idx: number) => {
-				images.push({
-					cid: recordCids[idx] ?? '',
-					thumb: img.thumb,
-					fullsize: img.fullsize,
-					alt: img.alt || '',
-					aspectRatio: img.aspectRatio
-				});
-			});
-		} else if (embed?.$type === 'app.bsky.embed.recordWithMedia#view') {
-			const media = (embed as any).media;
-			if (media?.$type === 'app.bsky.embed.images#view') {
-				media.images.forEach((img: any, idx: number) => {
-					images.push({
-						cid: recordCids[idx] ?? '',
-						thumb: img.thumb,
-						fullsize: img.fullsize,
-						alt: img.alt || '',
-						aspectRatio: img.aspectRatio
-					});
-				});
-			}
-		}
-
-		if (images.length > 0) {
-			posts.push({
-				uri: post.uri,
-				cid: post.cid,
-				author: {
-					did: post.author.did,
-					handle: post.author.handle,
-					displayName: post.author.displayName,
-					avatar: post.author.avatar
-				},
-				images,
-				indexedAt: post.indexedAt,
-				parentChain: [],
-				isRepost,
-				labels,
-				nsfw: isNsfw(labels)
-			});
+	for (let i = 0; i < unique.length; i += 25) {
+		const chunk = unique.slice(i, i + 25);
+		const res = await agent.getPosts({ uris: chunk });
+		for (const post of res.data.posts) {
+			const mapped = postViewToPhotoPost(post, false, isAuthenticated);
+			if (mapped) byUri.set(post.uri, mapped);
 		}
 	}
 
+	// Preserve the order of the input uris (dropping any that didn't resolve)
+	const seen = new Set<string>();
+	const ordered: PhotoPost[] = [];
+	for (const uri of uris) {
+		if (seen.has(uri)) continue;
+		seen.add(uri);
+		const post = byUri.get(uri);
+		if (post) ordered.push(post);
+	}
+	return ordered;
+}
+
+/**
+ * Full-text / hashtag post search via app.bsky.feed.searchPosts. Requires an
+ * authenticated agent (the public appview rejects unauthenticated searches).
+ * Returns only posts that carry image embeds.
+ */
+export async function searchPhotoPosts(
+	agent: BskyAgent,
+	query: string,
+	cursor?: string,
+	limit: number = 50
+): Promise<{ posts: PhotoPost[]; cursor?: string }> {
+	const res = await agent.app.bsky.feed.searchPosts({ q: query, limit, cursor });
+	const isAuthenticated = !!agent.session;
+	const posts: PhotoPost[] = [];
+	for (const post of res.data.posts) {
+		const mapped = postViewToPhotoPost(post, false, isAuthenticated);
+		if (mapped) posts.push(mapped);
+	}
 	return { posts, cursor: res.data.cursor };
 }
 

--- a/src/lib/api/bluesky.ts
+++ b/src/lib/api/bluesky.ts
@@ -43,10 +43,23 @@ export interface PhotoPost {
 }
 
 export interface PhotoImage {
+	cid: string;
 	thumb: string;
 	fullsize: string;
 	alt: string;
 	aspectRatio?: { width: number; height: number };
+}
+
+export function extractImageCids(record: any): string[] {
+	const embed = record?.embed;
+	if (!embed) return [];
+	let images: any[] | undefined;
+	if (embed.$type === 'app.bsky.embed.images') {
+		images = embed.images;
+	} else if (embed.$type === 'app.bsky.embed.recordWithMedia' && embed.media?.$type === 'app.bsky.embed.images') {
+		images = embed.media.images;
+	}
+	return (images ?? []).map((i: any) => i?.image?.ref?.toString() ?? '');
 }
 
 export async function getProfile(agent: BskyAgent, handle: string): Promise<ProfileInfo> {
@@ -103,27 +116,30 @@ export async function getPhotoPosts(
 		}
 
 		const images: PhotoImage[] = [];
+		const recordCids = extractImageCids((post as any).record);
 
 		if (embed?.$type === 'app.bsky.embed.images#view') {
-			for (const img of (embed as any).images) {
+			(embed as any).images.forEach((img: any, idx: number) => {
 				images.push({
+					cid: recordCids[idx] ?? '',
 					thumb: img.thumb,
 					fullsize: img.fullsize,
 					alt: img.alt || '',
 					aspectRatio: img.aspectRatio
 				});
-			}
+			});
 		} else if (embed?.$type === 'app.bsky.embed.recordWithMedia#view') {
 			const media = (embed as any).media;
 			if (media?.$type === 'app.bsky.embed.images#view') {
-				for (const img of media.images) {
+				media.images.forEach((img: any, idx: number) => {
 					images.push({
+						cid: recordCids[idx] ?? '',
 						thumb: img.thumb,
 						fullsize: img.fullsize,
 						alt: img.alt || '',
 						aspectRatio: img.aspectRatio
 					});
-				}
+				});
 			}
 		}
 

--- a/src/lib/api/entail.ts
+++ b/src/lib/api/entail.ts
@@ -1,23 +1,96 @@
 const ENTAIL_API = 'https://entail.dev/api';
 
-export interface EntailImageTags {
-	cid: string;
-	rating: string;
-	tags: string[];
+export type EntailRating = 'safe' | 'questionable' | 'explicit';
+
+export interface EntailTagScore {
+	name: string;
+	confidence: number;
 }
 
-export interface EntailTagsResponse {
+export interface EntailRouterScores {
+	furry: number;
+	artwork: number;
+}
+
+export interface EntailImageTags {
+	cid: string;
+	rating: string | null;
+	rating_score: number | null;
+	router: EntailRouterScores | null;
+	routed_pass: boolean | null;
+	tags: EntailTagScore[];
+}
+
+export interface EntailPostResponse {
 	uri: string;
+	model_version: string;
+	router_model_version: string | null;
 	images: EntailImageTags[];
 }
 
-export async function getPostTags(handle: string, rkey: string): Promise<EntailTagsResponse> {
+/**
+ * Forward lookup: given a Bluesky post, return per-image e621 tags with
+ * confidence scores. Hits GET /post (formerly /tags). Pass `force` to bypass
+ * the furry-artwork router gate and tag every image.
+ */
+export async function getPostTags(
+	handle: string,
+	rkey: string,
+	force = false
+): Promise<EntailPostResponse> {
 	const params = new URLSearchParams({ handle, rkey });
-	const res = await fetch(`${ENTAIL_API}/tags?${params.toString()}`);
+	if (force) params.set('force', 'true');
+	const res = await fetch(`${ENTAIL_API}/post?${params.toString()}`);
 
 	if (!res.ok) {
 		throw new Error(`Entail API error ${res.status}`);
 	}
 
-	return (await res.json()) as EntailTagsResponse;
+	return (await res.json()) as EntailPostResponse;
+}
+
+export interface EntailSearchMatch {
+	uri: string;
+	cid: string;
+	rating: string;
+	confidence: number;
+	indexed_at: string;
+}
+
+export interface EntailSearchResponse {
+	matches: EntailSearchMatch[];
+	cursor: string | null;
+}
+
+export interface EntailSearchOptions {
+	rating?: EntailRating;
+	/** Max results, clamped server-side to 200. Defaults to 50. */
+	limit?: number;
+	/** Opaque pagination cursor from a previous response. */
+	cursor?: string;
+}
+
+/**
+ * Reverse lookup: given a single e621 tag, return matching Bluesky posts.
+ * Hits GET /search. The API only supports one tag per call — for multi-tag
+ * AND/OR queries, fan out one call per tag and intersect/union on uri+cid.
+ * May return 503 while the inference server is migrating/under load.
+ */
+export async function searchByTag(
+	tag: string,
+	opts: EntailSearchOptions = {}
+): Promise<EntailSearchResponse> {
+	const params = new URLSearchParams({ tag });
+	if (opts.rating) params.set('rating', opts.rating);
+	if (opts.limit != null) params.set('limit', String(opts.limit));
+	if (opts.cursor) params.set('cursor', opts.cursor);
+
+	const res = await fetch(`${ENTAIL_API}/search?${params.toString()}`);
+
+	if (!res.ok) {
+		throw new Error(`Entail search error ${res.status}`);
+	}
+
+	const data = (await res.json()) as EntailSearchResponse;
+	return { matches: data.matches ?? [], cursor: data.cursor ?? null };
 }

--- a/src/lib/api/entail.ts
+++ b/src/lib/api/entail.ts
@@ -1,0 +1,23 @@
+const ENTAIL_API = 'https://entail.dev/api';
+
+export interface EntailImageTags {
+	cid: string;
+	rating: string;
+	tags: string[];
+}
+
+export interface EntailTagsResponse {
+	uri: string;
+	images: EntailImageTags[];
+}
+
+export async function getPostTags(handle: string, rkey: string): Promise<EntailTagsResponse> {
+	const params = new URLSearchParams({ handle, rkey });
+	const res = await fetch(`${ENTAIL_API}/tags?${params.toString()}`);
+
+	if (!res.ok) {
+		throw new Error(`Entail API error ${res.status}`);
+	}
+
+	return (await res.json()) as EntailTagsResponse;
+}

--- a/src/lib/components/PhotoModal.svelte
+++ b/src/lib/components/PhotoModal.svelte
@@ -4,6 +4,7 @@
 	import { getPostTags, type EntailImageTags } from '$lib/api/entail.js';
 	import { goto } from '$app/navigation';
 	import { authState, followUser, unfollowUser, getFollowStatus } from '$lib/stores/auth.js';
+	import { settings } from '$lib/stores/settings.js';
 	import DiscoveryPath from './DiscoveryPath.svelte';
 
 	interface Props {
@@ -37,6 +38,15 @@
 		fullImageLoaded = false;
 	});
 
+	// e621 tag gating — see issues #4 and #6.
+	// All three must be true: FurryList member, NSFW mode explicitly 'show', and 18+ per Bluesky birth date.
+	const e621Enabled = $derived(
+		$authState.isAuthenticated &&
+		$authState.uwu &&
+		$authState.ageVerified &&
+		$settings.nsfwMode === 'show'
+	);
+
 	let tagsByCid = $state<Record<string, EntailImageTags>>({});
 	let tagsLoading = $state(false);
 	let tagsError = $state<string | null>(null);
@@ -60,6 +70,7 @@
 	});
 
 	onMount(() => {
+		if (!e621Enabled) return;
 		tagsLoading = true;
 		getPostTags(post.author.did, rkey)
 			.then((r) => {
@@ -253,6 +264,7 @@
 					Open in Bluesky
 				</a>
 
+				{#if e621Enabled}
 				<div class="tags-section">
 					<h3>
 						e621 Tags
@@ -267,7 +279,7 @@
 					{:else if currentTags && currentTags.tags.length > 0}
 						<ul class="tag-list">
 							{#each visibleTags as tag}
-								<li class="tag">{tag}</li>
+								<li class="tag">{tag.name}</li>
 							{/each}
 							{#if hiddenTagCount > 0 && !tagsExpanded}
 								<li>
@@ -281,6 +293,7 @@
 						<p class="tags-status">No tags for this image.</p>
 					{/if}
 				</div>
+				{/if}
 
 				{#if post.parentChain.length > 0}
 					<div class="discovery-section desktop-only">

--- a/src/lib/components/PhotoModal.svelte
+++ b/src/lib/components/PhotoModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import type { PhotoPost } from '$lib/api/bluesky.js';
+	import { getPostTags, type EntailImageTags } from '$lib/api/entail.js';
 	import { goto } from '$app/navigation';
 	import { authState, followUser, unfollowUser, getFollowStatus } from '$lib/stores/auth.js';
 	import DiscoveryPath from './DiscoveryPath.svelte';
@@ -34,6 +35,44 @@
 		// Reset load state whenever the active image changes
 		void image.fullsize;
 		fullImageLoaded = false;
+	});
+
+	let tagsByCid = $state<Record<string, EntailImageTags>>({});
+	let tagsLoading = $state(false);
+	let tagsError = $state<string | null>(null);
+	let tagsExpanded = $state(false);
+	const TAG_LIMIT = 15;
+	const currentTags = $derived(image.cid ? tagsByCid[image.cid] : undefined);
+	const visibleTags = $derived(
+		currentTags
+			? tagsExpanded
+				? currentTags.tags
+				: currentTags.tags.slice(0, TAG_LIMIT)
+			: []
+	);
+	const hiddenTagCount = $derived(
+		currentTags ? Math.max(0, currentTags.tags.length - TAG_LIMIT) : 0
+	);
+
+	$effect(() => {
+		void image.cid;
+		tagsExpanded = false;
+	});
+
+	onMount(() => {
+		tagsLoading = true;
+		getPostTags(post.author.did, rkey)
+			.then((r) => {
+				const map: Record<string, EntailImageTags> = {};
+				for (const img of r.images) map[img.cid] = img;
+				tagsByCid = map;
+			})
+			.catch((e) => {
+				tagsError = e instanceof Error ? e.message : 'failed to load tags';
+			})
+			.finally(() => {
+				tagsLoading = false;
+			});
 	});
 
 	let followUri = $state<string | null>(null);
@@ -213,6 +252,35 @@
 					</svg>
 					Open in Bluesky
 				</a>
+
+				<div class="tags-section">
+					<h3>
+						e621 Tags
+						{#if currentTags}
+							<span class="rating-pill rating-{currentTags.rating}">{currentTags.rating}</span>
+						{/if}
+					</h3>
+					{#if tagsLoading}
+						<p class="tags-status">Loading…</p>
+					{:else if tagsError}
+						<p class="tags-status">{tagsError}</p>
+					{:else if currentTags && currentTags.tags.length > 0}
+						<ul class="tag-list">
+							{#each visibleTags as tag}
+								<li class="tag">{tag}</li>
+							{/each}
+							{#if hiddenTagCount > 0 && !tagsExpanded}
+								<li>
+									<button class="more-tags" type="button" onclick={() => (tagsExpanded = true)}>
+										and {hiddenTagCount} more
+									</button>
+								</li>
+							{/if}
+						</ul>
+					{:else}
+						<p class="tags-status">No tags for this image.</p>
+					{/if}
+				</div>
 
 				{#if post.parentChain.length > 0}
 					<div class="discovery-section desktop-only">
@@ -486,6 +554,91 @@
 
 	.bsky-link:hover {
 		background: var(--bg-muted);
+	}
+
+	.tags-section {
+		border-top: 1px solid var(--border);
+		padding-top: 16px;
+		margin-bottom: 16px;
+	}
+
+	.tags-section h3 {
+		margin: 0 0 12px;
+		font-family: 'JetBrains Mono', monospace;
+		font-size: 12px;
+		color: var(--fg-dim);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	.rating-pill {
+		font-family: 'JetBrains Mono', monospace;
+		font-size: 11px;
+		font-weight: 600;
+		padding: 2px 8px;
+		border-radius: 9999px;
+		border: 1px solid currentColor;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+
+	.rating-safe {
+		color: #3ba55c;
+		background: rgba(59, 165, 92, 0.12);
+	}
+
+	.rating-questionable {
+		color: #e0a83a;
+		background: rgba(224, 168, 58, 0.12);
+	}
+
+	.rating-explicit {
+		color: #e0533a;
+		background: rgba(224, 83, 58, 0.12);
+	}
+
+	.tags-status {
+		margin: 0;
+		font-family: 'JetBrains Mono', monospace;
+		font-size: 13px;
+		color: var(--fg-subtle);
+	}
+
+	.tag-list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-wrap: wrap;
+		gap: 6px;
+	}
+
+	.tag {
+		font-family: 'JetBrains Mono', monospace;
+		font-size: 12px;
+		color: var(--fg-muted);
+		background: var(--bg-muted);
+		border: 1px solid var(--border);
+		border-radius: 9999px;
+		padding: 4px 10px;
+	}
+
+	.more-tags {
+		font-family: 'JetBrains Mono', monospace;
+		font-size: 12px;
+		color: var(--fg-subtle);
+		background: none;
+		border: none;
+		padding: 4px 4px;
+		cursor: pointer;
+		user-select: text;
+	}
+
+	.more-tags:hover {
+		color: var(--accent-purple);
 	}
 
 	.discovery-section {

--- a/src/lib/components/SearchBar.svelte
+++ b/src/lib/components/SearchBar.svelte
@@ -20,9 +20,22 @@
 		return cleaned;
 	}
 
+	// Content queries (#hashtag / tag:e621) go to the search page; a plain
+	// handle still jumps straight to that account's mosaic.
+	function isContentQuery(input: string): boolean {
+		return /(^|\s)(#|tag:|from:)/i.test(input);
+	}
+
 	function onSubmit(e: Event) {
 		e.preventDefault();
-		const resolved = parseHandle(handle);
+		const trimmed = handle.trim();
+		if (!trimmed) return;
+		if (isContentQuery(trimmed)) {
+			goto(`/search?q=${encodeURIComponent(trimmed)}`);
+			handle = '';
+			return;
+		}
+		const resolved = parseHandle(trimmed);
 		if (resolved) {
 			goto(`/mosaic/${encodeURIComponent(resolved)}`);
 			handle = '';

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -49,9 +49,21 @@
 		return cleaned;
 	}
 
+	// Content queries (#hashtag / tag:e621 / from:) go to the search page; a
+	// plain handle still jumps straight to that account's mosaic.
+	function isContentQuery(input: string): boolean {
+		return /(^|\s)(#|tag:|from:)/i.test(input);
+	}
+
 	function onSubmit(e: Event) {
 		e.preventDefault();
-		const resolved = parseHandle(handle);
+		const trimmed = handle.trim();
+		if (!trimmed) return;
+		if (isContentQuery(trimmed)) {
+			goto(`/search?q=${encodeURIComponent(trimmed)}`);
+			return;
+		}
+		const resolved = parseHandle(trimmed);
 		if (resolved) {
 			goto(`/mosaic/${encodeURIComponent(resolved)}`);
 		}
@@ -69,7 +81,7 @@
 			<input
 				type="text"
 				bind:value={handle}
-				placeholder="Enter a handle (e.g. alice.bsky.social)"
+				placeholder="Handle, #hashtag, or tag:fennec_fox"
 			/>
 			<button type="submit" disabled={!handle.trim()}>Explore</button>
 		</form>

--- a/src/routes/mosaic/[handle]/post/[rkey]/+page.ts
+++ b/src/routes/mosaic/[handle]/post/[rkey]/+page.ts
@@ -1,5 +1,5 @@
 import { error } from '@sveltejs/kit';
-import { createAgent, type PhotoImage, type PhotoPost } from '$lib/api/bluesky.js';
+import { createAgent, extractImageCids, type PhotoImage, type PhotoPost } from '$lib/api/bluesky.js';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ params }) => {
@@ -31,27 +31,30 @@ export const load: PageLoad = async ({ params }) => {
 	const p = thread.post;
 	const embed = p.embed;
 	const images: PhotoImage[] = [];
+	const recordCids = extractImageCids(p.record);
 
 	if (embed?.$type === 'app.bsky.embed.images#view') {
-		for (const img of (embed as any).images) {
+		(embed as any).images.forEach((img: any, idx: number) => {
 			images.push({
+				cid: recordCids[idx] ?? '',
 				thumb: img.thumb,
 				fullsize: img.fullsize,
 				alt: img.alt || '',
 				aspectRatio: img.aspectRatio
 			});
-		}
+		});
 	} else if (embed?.$type === 'app.bsky.embed.recordWithMedia#view') {
 		const media = (embed as any).media;
 		if (media?.$type === 'app.bsky.embed.images#view') {
-			for (const img of media.images) {
+			media.images.forEach((img: any, idx: number) => {
 				images.push({
+					cid: recordCids[idx] ?? '',
 					thumb: img.thumb,
 					fullsize: img.fullsize,
 					alt: img.alt || '',
 					aspectRatio: img.aspectRatio
 				});
-			}
+			});
 		}
 	}
 

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -1,9 +1,41 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
+	import {
+		createAgent,
+		getPhotoPostsByUris,
+		searchPhotoPosts,
+		type PhotoPost
+	} from '$lib/api/bluesky.js';
+	import { searchByTag, type EntailRating, type EntailSearchMatch } from '$lib/api/entail.js';
+	import { getAuthenticatedAgent, authState } from '$lib/stores/auth.js';
+	import { settings } from '$lib/stores/settings.js';
+	import Mosaic from '$lib/components/Mosaic.svelte';
+	import PhotoModal from '$lib/components/PhotoModal.svelte';
 
-	let handle = $state('');
+	let query = $state('');
+	let matchAll = $state(true);
 
-	function parseHandle(input: string): string {
+	let loading = $state(false);
+	let error = $state<string | null>(null);
+	let results = $state<PhotoPost[]>([]);
+	let searched = $state(false);
+
+	let modalPost = $state<PhotoPost | null>(null);
+	let modalImageIndex = $state(0);
+
+	function getAgent() {
+		return getAuthenticatedAgent() || createAgent();
+	}
+
+	interface ParsedQuery {
+		handle: string | null; // set only for a pure account-lookup query
+		e621Tags: string[];
+		hashtags: string[];
+		from: string | null;
+	}
+
+	function parseHandleToken(input: string): string {
 		let cleaned = input.trim().replace(/^@/, '');
 		const urlMatch = cleaned.match(/bsky\.app\/profile\/([^/?#]+)/);
 		if (urlMatch) cleaned = urlMatch[1];
@@ -11,27 +43,272 @@
 		return cleaned;
 	}
 
+	// e621 tags are canonically lowercase and underscore-joined (fennec_fox,
+	// not "fennec fox"). Strip surrounding quotes and map spaces to underscores.
+	function normalizeTag(value: string): string {
+		return value
+			.trim()
+			.replace(/^"(.*)"$/s, '$1')
+			.trim()
+			.toLowerCase()
+			.replace(/\s+/g, '_');
+	}
+
+	// Parse a query into fields. Each field is introduced by `tag:`, `#`, or
+	// `from:` and its value runs until the next introducer (or end). This makes
+	// a tag value greedy, so `tag:fennec fox` → `fennec_fox` without quotes,
+	// while `tag:wolf tag:forest` still yields two tags. Quotes are optional.
+	function parseQuery(input: string): ParsedQuery {
+		const trimmed = input.trim();
+		const e621Tags: string[] = [];
+		const hashtags: string[] = [];
+		let from: string | null = null;
+
+		const introRe = /(tag:|from:|#)/gi;
+		const intros: { kind: string; start: number; valueStart: number }[] = [];
+		let m: RegExpExecArray | null;
+		while ((m = introRe.exec(trimmed)) !== null) {
+			intros.push({
+				kind: m[1].toLowerCase(),
+				start: m.index,
+				valueStart: m.index + m[1].length
+			});
+		}
+
+		// No structured fields → treat the whole input as an account lookup.
+		if (intros.length === 0) {
+			return { handle: parseHandleToken(trimmed), e621Tags, hashtags, from: null };
+		}
+
+		for (let i = 0; i < intros.length; i++) {
+			const valEnd = i + 1 < intros.length ? intros[i + 1].start : trimmed.length;
+			const raw = trimmed.slice(intros[i].valueStart, valEnd).trim();
+			if (!raw) continue;
+			if (intros[i].kind === 'tag:') {
+				const v = normalizeTag(raw);
+				if (v) e621Tags.push(v);
+			} else if (intros[i].kind === '#') {
+				// Hashtags are single words — take only the first.
+				const v = raw.split(/\s+/)[0];
+				if (v) hashtags.push(v);
+			} else {
+				// from: — single handle token.
+				const v = parseHandleToken(raw.split(/\s+/)[0]);
+				if (v) from = v;
+			}
+		}
+
+		return { handle: null, e621Tags, hashtags, from };
+	}
+
+	// Follow the cursor for one entail tag, capped so a single query can't
+	// hammer Zenith's CPU-bound server.
+	const MAX_MATCHES_PER_TAG = 200;
+	async function collectTagMatches(
+		tag: string,
+		rating?: EntailRating
+	): Promise<EntailSearchMatch[]> {
+		const all: EntailSearchMatch[] = [];
+		let cursor: string | undefined;
+		do {
+			const res = await searchByTag(tag, { rating, limit: 200, cursor });
+			all.push(...res.matches);
+			cursor = res.cursor ?? undefined;
+		} while (cursor && all.length < MAX_MATCHES_PER_TAG);
+		return all;
+	}
+
+	// Intersect (AND) or union (OR) per-tag entail matches on image cid, then
+	// return the matching post uris in a stable order.
+	function combineByCid(perTag: EntailSearchMatch[][], all: boolean): string[] {
+		if (perTag.length === 0) return [];
+		const cidToUri = new Map<string, string>();
+		for (const list of perTag) {
+			for (const m of list) if (!cidToUri.has(m.cid)) cidToUri.set(m.cid, m.uri);
+		}
+		const sets = perTag.map((list) => new Set(list.map((m) => m.cid)));
+		let cids: string[];
+		if (all) {
+			const [first, ...rest] = sets;
+			cids = [...first].filter((cid) => rest.every((s) => s.has(cid)));
+		} else {
+			cids = [...new Set(sets.flatMap((s) => [...s]))];
+		}
+		const seen = new Set<string>();
+		const uris: string[] = [];
+		for (const cid of cids) {
+			const uri = cidToUri.get(cid);
+			if (uri && !seen.has(uri)) {
+				seen.add(uri);
+				uris.push(uri);
+			}
+		}
+		return uris;
+	}
+
+	// Intersect (AND) or union (OR) per-hashtag post lists on post uri.
+	function combinePostsByUri(perTag: PhotoPost[][], all: boolean): PhotoPost[] {
+		if (perTag.length === 0) return [];
+		if (perTag.length === 1) return perTag[0];
+		const byUri = new Map<string, PhotoPost>();
+		for (const list of perTag) for (const p of list) byUri.set(p.uri, p);
+		if (all) {
+			const sets = perTag.map((list) => new Set(list.map((p) => p.uri)));
+			const [first, ...rest] = sets;
+			return [...first]
+				.filter((u) => rest.every((s) => s.has(u)))
+				.map((u) => byUri.get(u))
+				.filter((p): p is PhotoPost => !!p);
+		}
+		return [...byUri.values()];
+	}
+
+	// Submitting just syncs the query into the URL; the $effect below is the
+	// single place that runs the search, so the nav SearchBar (?q=…), the page
+	// form, and shared links all behave identically.
 	function onSubmit(e: Event) {
 		e.preventDefault();
-		const resolved = parseHandle(handle);
-		if (resolved) {
-			goto(`/mosaic/${encodeURIComponent(resolved)}`);
+		const trimmed = query.trim();
+		if (!trimmed) return;
+		goto(`/search?q=${encodeURIComponent(trimmed)}`, { keepFocus: true, noScroll: true });
+	}
+
+	let lastRun = '';
+	$effect(() => {
+		const q = page.url.searchParams.get('q') ?? '';
+		if (q && q !== lastRun) {
+			lastRun = q;
+			query = q;
+			runSearch();
 		}
+	});
+
+	async function runSearch() {
+		if (loading) return;
+		const parsed = parseQuery(query);
+
+		// Pure identity query → route to the account mosaic (original behavior).
+		if (parsed.e621Tags.length === 0 && parsed.hashtags.length === 0) {
+			if (parsed.handle) goto(`/mosaic/${encodeURIComponent(parsed.handle)}`);
+			return;
+		}
+
+		if (parsed.hashtags.length > 0 && !$authState.isAuthenticated) {
+			error = 'Hashtag search requires signing in with your Bluesky account.';
+			results = [];
+			searched = true;
+			return;
+		}
+
+		loading = true;
+		error = null;
+		searched = true;
+		results = [];
+		modalPost = null;
+
+		try {
+			const agent = getAgent();
+			// Respect the account-wide NSFW setting: 'hide' restricts e621 results
+			// to safe; 'blur'/'show' allow all ratings (the Mosaic blurs/reveals
+			// label-flagged posts per the same setting).
+			const rating: EntailRating | undefined = $settings.nsfwMode === 'hide' ? 'safe' : undefined;
+
+			// e621 tag search (reverse lookup via entail) → matching post uris.
+			let e621Uris: string[] | null = null;
+			if (parsed.e621Tags.length > 0) {
+				const perTag = await Promise.all(
+					parsed.e621Tags.map((tag) => collectTagMatches(tag, rating))
+				);
+				e621Uris = combineByCid(perTag, matchAll);
+			}
+
+			// Hashtag search (Bluesky searchPosts, authenticated).
+			let hashtagPosts: PhotoPost[] | null = null;
+			if (parsed.hashtags.length > 0) {
+				const perTag = await Promise.all(
+					parsed.hashtags.map((h) =>
+						searchPhotoPosts(agent, `#${h}`, undefined, 50).then((r) => r.posts)
+					)
+				);
+				hashtagPosts = combinePostsByUri(perTag, matchAll);
+			}
+
+			// Combine the two result sets (intersect when both are present).
+			let finalPosts: PhotoPost[];
+			if (e621Uris !== null && hashtagPosts !== null) {
+				const e621Set = new Set(e621Uris);
+				finalPosts = hashtagPosts.filter((p) => e621Set.has(p.uri));
+			} else if (e621Uris !== null) {
+				finalPosts = await getPhotoPostsByUris(agent, e621Uris);
+			} else {
+				finalPosts = hashtagPosts ?? [];
+			}
+
+			// Optional account restriction (from:handle).
+			if (parsed.from) {
+				const f = parsed.from.toLowerCase();
+				finalPosts = finalPosts.filter(
+					(p) => p.author.handle.toLowerCase() === f || p.author.did.toLowerCase() === f
+				);
+			}
+
+			results = finalPosts;
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Search failed';
+		} finally {
+			loading = false;
+		}
+	}
+
+	function onPhotoClick(post: PhotoPost, imageIndex: number) {
+		modalPost = post;
+		modalImageIndex = imageIndex;
+	}
+
+	function closeModal() {
+		modalPost = null;
 	}
 </script>
 
-<div class="search-page">
-	<h1>Search</h1>
-	<p class="subtitle">Find a Bluesky account to explore</p>
-	<form class="search-form" onsubmit={onSubmit}>
-		<input
-			type="text"
-			bind:value={handle}
-			placeholder="Enter a handle (e.g. alice.bsky.social)"
-		/>
-		<button type="submit" disabled={!handle.trim()}>Search</button>
-	</form>
+<div class="search-page" class:has-results={searched}>
+	<div class="search-head">
+		<h1>Search</h1>
+		<p class="subtitle">
+			Find an account, or search by <code>#hashtag</code> and <code>tag:</code> (e621)
+		</p>
+		<form class="search-form" onsubmit={onSubmit}>
+			<input
+				type="text"
+				bind:value={query}
+				placeholder={'handle, #hashtag, or tag:fennec_fox tag:"red panda"'}
+			/>
+			<button type="submit" disabled={!query.trim() || loading}>
+				{loading ? 'Searching…' : 'Search'}
+			</button>
+		</form>
+		<div class="search-options">
+			<label class="opt">
+				<input type="checkbox" bind:checked={matchAll} />
+				Match all tags
+			</label>
+		</div>
+	</div>
+
+	{#if loading}
+		<div class="status">Searching…</div>
+	{:else if error}
+		<div class="status error">{error}</div>
+	{:else if searched && results.length === 0}
+		<div class="status">No posts found for this search.</div>
+	{:else if results.length > 0}
+		<div class="results-count">{results.length} result{results.length === 1 ? '' : 's'}</div>
+		<Mosaic posts={results} {onPhotoClick} />
+	{/if}
 </div>
+
+{#if modalPost}
+	<PhotoModal post={modalPost} imageIndex={modalImageIndex} onclose={closeModal} />
+{/if}
 
 <style>
 	.search-page {
@@ -43,6 +320,20 @@
 		padding: 2rem;
 		gap: 12px;
 		min-height: calc(100vh - 200px);
+	}
+
+	/* Once a search has run, anchor the form to the top instead of centering. */
+	.search-page.has-results {
+		justify-content: flex-start;
+		min-height: auto;
+	}
+
+	.search-head {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 12px;
+		width: 100%;
 	}
 
 	h1 {
@@ -57,6 +348,16 @@
 		font-family: 'Geist', sans-serif;
 		font-size: 14px;
 		margin-bottom: 16px;
+		text-align: center;
+	}
+
+	.subtitle code {
+		font-family: 'Geist Mono', monospace;
+		font-size: 12px;
+		background: var(--input-bg);
+		padding: 1px 5px;
+		border-radius: 5px;
+		color: var(--accent-purple);
 	}
 
 	.search-form {
@@ -67,7 +368,7 @@
 		max-width: 400px;
 	}
 
-	input {
+	input[type='text'] {
 		padding: 12px 16px;
 		border: 1px solid var(--border);
 		border-radius: 9999px;
@@ -79,11 +380,11 @@
 		transition: border-color 0.2s;
 	}
 
-	input:focus {
+	input[type='text']:focus {
 		border-color: var(--accent-purple);
 	}
 
-	input::placeholder {
+	input[type='text']::placeholder {
 		color: var(--fg-subtle);
 	}
 
@@ -107,5 +408,51 @@
 	button:disabled {
 		opacity: 0.5;
 		cursor: not-allowed;
+	}
+
+	.search-options {
+		display: flex;
+		gap: 16px;
+		flex-wrap: wrap;
+		justify-content: center;
+	}
+
+	.opt {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		font-family: 'Geist', sans-serif;
+		font-size: 13px;
+		color: var(--fg-dim);
+		cursor: pointer;
+	}
+
+	.opt input {
+		accent-color: var(--accent-purple);
+		cursor: pointer;
+	}
+
+	.status {
+		font-family: 'Geist', sans-serif;
+		font-size: 14px;
+		color: var(--fg-dim);
+		padding: 24px;
+		text-align: center;
+	}
+
+	.status.error {
+		color: #e5484d;
+	}
+
+	.results-count {
+		font-family: 'Geist', sans-serif;
+		font-size: 13px;
+		color: var(--fg-subtle);
+		align-self: flex-start;
+		padding: 8px 24px 0;
+	}
+
+	.search-page.has-results :global(.mosaic) {
+		width: 100%;
 	}
 </style>


### PR DESCRIPTION
Implements the core of #3 — turns the search page into a true content search alongside the existing account lookup, backed by Zenith's [entail](https://entail.dev/api/docs) API (the `/search` reverse-lookup endpoint went live 2026-06-08).

## What's new
A single smart search bar (on `/search`, the header `SearchBar`, and the splash page) that routes by input:

| Input | Behavior |
|---|---|
| `alice.bsky.social` / `@alice` / `bsky.app/profile/…` | Account lookup → `/mosaic/[handle]` (unchanged) |
| `tag:fennec_fox` / `tag:fennec fox` / `tag:"red panda"` | e621 reverse search via entail `/search` |
| `tag:wolf tag:forest` | Multiple tags, combined |
| `#furryart` | Bluesky `searchPosts` (requires login) |
| `#furryart tag:wolf` | Combined, intersected |
| `… from:alice.bsky.social` | Restrict to one account |

Plus a **Match all tags** (AND/OR) toggle. Results render in the existing `Mosaic` with the photo modal.

## Implementation
- **`entail.ts`**: repoint `/tags` → `/post` (renamed upstream), model the real `{name, confidence}` tag schema + `rating_score`/`router`/`routed_pass`, add `searchByTag()`.
- **`bluesky.ts`**: extract shared `postViewToPhotoPost()`; add `getPhotoPostsByUris()` (hydrate match URIs via `getPosts`, batched ≤25) and `searchPhotoPosts()`.
- **search page**: greedy tag parsing (underscore-normalized to e621's vocabulary), AND/OR combine on `cid`/`uri`, `?q=`-driven so all three bars feed it.
- **NSFW**: follows the account-wide `nsfwMode` setting (`hide` → `rating=safe`), no per-search override.
- **`PhotoModal`**: renders `tag.name` now that tags carry confidence.

## Known caveats (tracked in #3)
- **Single tag per `/search` call.** Multi-tag AND fans out client-side and intersects within each tag's most-recent 200-match window, so it can under-return for rare combos.
- **Exact-match vocabulary**, no synonyms/stemming — `fennec` ≠ `fennec_fox`. Real fix is tag autocomplete (needs a vocabulary endpoint from entail).
- **Hashtag search requires auth** (`searchPosts` is rejected unauthenticated); e621 `tag:` search works logged-out.
- Handle entail `503` gracefully — Zenith is migrating inference to a home server.

Verified: `npm run check` (0 errors) and `npm run build` clean; e621 search → hydration pipeline tested end-to-end against the live API.