### PR TITLE
Add like button to the photo modal

### DIFF
--- a/src/lib/components/PhotoModal.svelte
+++ b/src/lib/components/PhotoModal.svelte
@@ -2,7 +2,15 @@
 	import { onMount } from 'svelte';
 	import type { PhotoPost } from '$lib/api/bluesky.js';
 	import { goto } from '$app/navigation';
-	import { authState, followUser, unfollowUser, getFollowStatus } from '$lib/stores/auth.js';
+	import {
+		authState,
+		followUser,
+		unfollowUser,
+		getFollowStatus,
+		likePost,
+		unlikePost,
+		getLikeStatus
+	} from '$lib/stores/auth.js';
 	import DiscoveryPath from './DiscoveryPath.svelte';
 
 	interface Props {
@@ -67,6 +75,42 @@
 			console.error('Follow/unfollow failed:', err);
 		} finally {
 			followLoading = false;
+		}
+	}
+
+	let likeUri = $state<string | null>(null);
+	let likeLoading = $state(false);
+
+	$effect(() => {
+		if ($authState.isAuthenticated) {
+			checkLike(post.uri);
+		} else {
+			likeUri = null;
+		}
+	});
+
+	async function checkLike(uri: string) {
+		try {
+			likeUri = await getLikeStatus(uri);
+		} catch {
+			likeUri = null;
+		}
+	}
+
+	async function handleLike() {
+		if (likeLoading || !$authState.isAuthenticated) return;
+		likeLoading = true;
+		try {
+			if (likeUri) {
+				await unlikePost(likeUri);
+				likeUri = null;
+			} else {
+				likeUri = await likePost(post.uri, post.cid);
+			}
+		} catch (err) {
+			console.error('Like/unlike failed:', err);
+		} finally {
+			likeLoading = false;
 		}
 	}
 
@@ -184,24 +228,40 @@
 							<span class="handle">@{post.author.handle}</span>
 						</div>
 					</button>
-					{#if $authState.isAuthenticated && post.author.did !== $authState.did}
-						<button
-							class="follow-btn desktop-only"
-							class:following={!!followUri}
-							onclick={handleFollow}
-							disabled={followLoading}
-							type="button"
-						>
-							{#if followLoading}
-								...
-							{:else if followUri}
-								<span class="follow-label">Following</span>
-								<span class="unfollow-label">Unfollow</span>
-							{:else}
-								Follow
-							{/if}
-						</button>
-					{/if}
+					<div class="author-actions">
+						{#if $authState.isAuthenticated}
+							<button
+								class="like-btn"
+								class:liked={!!likeUri}
+								onclick={handleLike}
+								disabled={likeLoading}
+								type="button"
+								aria-label={likeUri ? 'Unlike post' : 'Like post'}
+								title={likeUri ? 'Unlike' : 'Like'}
+							>
+								<span class="like-emoji">{likeUri ? '❤️' : '🤍'}</span>
+								<span class="like-label">{likeUri ? 'Liked' : 'Like'}</span>
+							</button>
+						{/if}
+						{#if $authState.isAuthenticated && post.author.did !== $authState.did}
+							<button
+								class="follow-btn desktop-only"
+								class:following={!!followUri}
+								onclick={handleFollow}
+								disabled={followLoading}
+								type="button"
+							>
+								{#if followLoading}
+									...
+								{:else if followUri}
+									<span class="follow-label">Following</span>
+									<span class="unfollow-label">Unfollow</span>
+								{:else}
+									Follow
+								{/if}
+							</button>
+						{/if}
+					</div>
 				</div>
 
 				<!-- Desktop: inline link -->
@@ -402,6 +462,48 @@
 		align-items: center;
 		justify-content: space-between;
 		margin-bottom: 16px;
+	}
+
+	.author-actions {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		flex-shrink: 0;
+	}
+
+	.like-btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		padding: 7px 14px;
+		border: 1px solid var(--border);
+		border-radius: 9999px;
+		background: var(--input-bg);
+		color: var(--fg);
+		font-family: 'Geist', sans-serif;
+		font-size: 14px;
+		font-weight: 600;
+		cursor: pointer;
+		transition: border-color 0.2s, background 0.2s, color 0.2s;
+	}
+
+	.like-btn:hover:not(:disabled) {
+		border-color: #ec4899;
+	}
+
+	.like-btn.liked {
+		border-color: #ec4899;
+		color: #ec4899;
+	}
+
+	.like-btn .like-emoji {
+		font-size: 15px;
+		line-height: 1;
+	}
+
+	.like-btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
 	}
 
 	.author-info {

--- a/src/lib/stores/auth.ts
+++ b/src/lib/stores/auth.ts
@@ -375,3 +375,24 @@ export async function getFollowStatus(did: string): Promise<string | null> {
 	const viewer = res.data.viewer;
 	return viewer?.following || null;
 }
+
+export async function likePost(uri: string, cid: string): Promise<string> {
+	const agent = getAuthenticatedAgent();
+	if (!agent) throw new Error('Not logged in');
+	const res = await agent.like(uri, cid);
+	return res.uri;
+}
+
+export async function unlikePost(likeUri: string): Promise<void> {
+	const agent = getAuthenticatedAgent();
+	if (!agent) throw new Error('Not logged in');
+	await agent.deleteLike(likeUri);
+}
+
+export async function getLikeStatus(uri: string): Promise<string | null> {
+	const agent = getAuthenticatedAgent();
+	if (!agent) return null;
+	const res = await agent.getPosts({ uris: [uri] });
+	const viewer = res.data.posts[0]?.viewer;
+	return viewer?.like || null;
+}


### PR DESCRIPTION
Adds a like button to the photo modal so signed-in users can like/unlike a post without leaving the mosaic.

## What's new
- A **like button** in the modal's author row: 🤍 **Like** → ❤️ **Liked**, toggling on click (pink accent when liked, disabled while in flight).
- On open (when authenticated), the modal checks whether you've already liked the post and reflects it.
- Shown only when signed in (likes are a write action); appears for any post, including your own.

## Implementation
- **`auth.ts`**: `likePost(uri, cid)` → `agent.like()`, `unlikePost(likeUri)` → `agent.deleteLike()`, `getLikeStatus(uri)` → reads `viewer.like` from `getPosts`. Mirrors the existing follow helpers.
- **`PhotoModal.svelte`**: like state + handler mirroring follow; button wrapped with the follow button in an `.author-actions` container so the `space-between` layout still anchors author left / actions right. Optimistic state via the returned like URI.

`npm run check` → 0 errors. Independent of the search work in #14.