### PR TITLE
Show Discovery Path in photo modal on mobile

### DIFF
--- a/src/lib/components/DiscoveryPath.svelte
+++ b/src/lib/components/DiscoveryPath.svelte
@@ -11,7 +11,8 @@
 	let { chain, current, onnavigate }: Props = $props();
 
 	function navigateTo(handle: string) {
-		window.open(`/mosaic/${encodeURIComponent(handle)}`, '_blank');
+		window.open(`/mosaic/${encodeURIComponent(handle)}`, '_blank', 'noopener,noreferrer');
+		onnavigate?.();
 	}
 </script>
 
@@ -24,8 +25,9 @@
 				<span class="node-initials">{(node.displayName || node.handle).slice(0, 2).toUpperCase()}</span>
 			{/if}
 			<span class="node-handle">@{node.handle}</span>
+			<span class="visually-hidden">(opens in new tab)</span>
 		</button>
-		<span class="arrow">&rarr;</span>
+		<span class="arrow" aria-hidden="true">&rarr;</span>
 	{/each}
 	<button class="path-node current" onclick={() => navigateTo(current.handle)} type="button">
 		{#if current.avatar}
@@ -34,6 +36,7 @@
 			<span class="node-initials">{(current.displayName || current.handle).slice(0, 2).toUpperCase()}</span>
 		{/if}
 		<span class="node-handle">@{current.handle}</span>
+		<span class="visually-hidden">(opens in new tab)</span>
 	</button>
 </div>
 
@@ -98,10 +101,36 @@
 		font-family: 'Geist Mono', monospace;
 		font-size: 12px;
 		color: var(--fg-muted);
+		max-width: 200px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 
 	.arrow {
 		color: var(--fg-dim);
 		font-size: 14px;
+	}
+
+	.visually-hidden {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
+	}
+
+	@media (max-width: 768px) {
+		.path-node {
+			min-height: 44px;
+		}
+
+		.node-handle {
+			max-width: 160px;
+		}
 	}
 </style>

--- a/src/lib/components/PhotoModal.svelte
+++ b/src/lib/components/PhotoModal.svelte
@@ -356,7 +356,7 @@
 				{/if}
 
 				{#if post.parentChain.length > 0}
-					<div class="discovery-section desktop-only">
+					<div class="discovery-section">
 						<h3>Discovery Path</h3>
 						<DiscoveryPath chain={post.parentChain} current={post.author} onnavigate={onclose} />
 					</div>


### PR DESCRIPTION
## Summary

The Discovery Path section in the photo modal was desktop-only; this makes it render on mobile (≤768px) too, plus polish surfaced by review:

- `PhotoModal.svelte`: removed the `desktop-only` class from the Discovery Path section.
- `DiscoveryPath.svelte`:
  - `window.open` now passes `noopener,noreferrer`.
  - Tapping a path node closes the modal after opening the profile (wires up the previously-unused `onnavigate` prop).
  - Long handles truncate with an ellipsis (max-width 200px desktop / 160px mobile) instead of overflowing narrow screens.
  - 44px minimum touch targets on mobile; desktop chip density unchanged.
  - `aria-hidden` on the decorative → separators and screen-reader-only "(opens in new tab)" labels on the buttons.

## Testing

- `npm run check`: 0 errors (8 pre-existing warnings, none in changed files).
- `npm run build` (adapter-cloudflare): succeeds.
- Driven end-to-end in Chromium with live data (`/mosaic/pfrazee.com` → Crawl Reposts → reposted photo modal):
  - Mobile 390×844: Discovery Path visible, chips ≥44px tall, tap opens `/mosaic/<handle>` in a new tab and closes the modal, long handles clip with ellipsis.
  - Desktop 1280×900: section still renders, chips unchanged at ~34px.
- No automated regression test: the repo has no test harness — tracked in #18.

Follow-up polish deferred to #19.