### PR TITLE
Show e621 tags on mobile, fix empty rating chip, anchor discovery chains to the root artist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ images/
 
 # IDE
 .idea/
+
+# Ship review artifacts
+.ship/

--- a/src/lib/api/crawler.ts
+++ b/src/lib/api/crawler.ts
@@ -71,17 +71,21 @@ async function processWithConcurrency<T, R>(
 export async function* crawlReposts(
 	agent: BskyAgent,
 	startHandle: string,
-	options: Partial<CrawlOptions> = {}
+	options: Partial<CrawlOptions> = {},
+	startProfile?: ProfileInfo
 ): AsyncGenerator<CrawlEvent> {
 	const opts = { ...DEFAULT_OPTIONS, ...options };
 	const visited = new Set<string>();
 	let totalPhotos = 0;
 
-	// Depth 0: starting account
-	visited.add(startHandle);
+	// Depth 0: starting account. Prefer the canonical handle from the profile —
+	// the route param may differ in case (e.g. phone keyboards auto-capitalize),
+	// while feed items always carry the canonical lowercase handle.
+	const rootHandle = startProfile?.handle ?? startHandle;
+	visited.add(rootHandle);
 
 	let currentLevel: { handle: string; profile?: ProfileInfo; parentChain: ProfileInfo[] }[] = [
-		{ handle: startHandle, parentChain: [] }
+		{ handle: rootHandle, profile: startProfile, parentChain: [] }
 	];
 
 	for (let depth = 0; depth <= opts.maxDepth; depth++) {
@@ -145,7 +149,7 @@ export async function* crawlReposts(
 						// For depth 0, get profile from any post authored by this account
 						// For deeper levels, use the stored profile
 						for (const item of res.data.feed) {
-							if (item.post.author.handle === account.handle) {
+							if (item.post.author.handle.toLowerCase() === account.handle.toLowerCase()) {
 								currentProfile = {
 									did: item.post.author.did,
 									handle: item.post.author.handle,

--- a/src/lib/components/PhotoModal.svelte
+++ b/src/lib/components/PhotoModal.svelte
@@ -75,37 +75,53 @@
 	// API and is interpolated into a class name.
 	const KNOWN_RATINGS: EntailRating[] = ['safe', 'questionable', 'explicit'];
 	const currentRating = $derived(KNOWN_RATINGS.find((r) => r === currentTags?.rating) ?? null);
+	// One always-mounted role="status" element whose text changes announces
+	// reliably; empty string while the tag list is showing.
+	const tagsStatus = $derived(
+		tagsLoading
+			? 'Loading…'
+			: tagsError
+				? tagsError
+				: currentTags && currentTags.tags.length > 0
+					? ''
+					: 'No tags for this image.'
+	);
 
 	$effect(() => {
 		void image.cid;
 		tagsExpanded = false;
 	});
 
-	// Fetch once e621Enabled becomes true — auth (uwu/ageVerified) resolves
-	// asynchronously after mount, so an onMount check would skip the fetch
-	// when the modal is opened via a direct post URL.
+	// Fetch reactively: auth (uwu/ageVerified) resolves asynchronously after mount.
 	// Plain (non-$state) on purpose: the guard must not be a tracked dependency.
-	let tagsRequestedFor: string | null = null;
+	let tagsRequest: { rkey: string } | null = null;
 	$effect(() => {
 		if (!e621Enabled) {
-			// Allow a refetch after logout→login or a failed request.
-			tagsRequestedFor = null;
+			// Re-arm the guard (an e621Enabled false→true toggle refetches) and
+			// invalidate any in-flight request.
+			tagsRequest = null;
 			tagsError = null;
+			tagsLoading = false;
 			return;
 		}
-		if (tagsRequestedFor === rkey) return;
-		tagsRequestedFor = rkey;
+		if (tagsRequest?.rkey === rkey) return;
+		const request = { rkey };
+		tagsRequest = request;
+		tagsError = null;
 		tagsLoading = true;
 		getPostTags(post.author.did, rkey)
 			.then((r) => {
+				if (tagsRequest !== request) return; // stale response
 				const map: Record<string, EntailImageTags> = {};
 				for (const img of r.images) map[img.cid] = img;
 				tagsByCid = map;
 			})
 			.catch((e) => {
+				if (tagsRequest !== request) return; // stale response
 				tagsError = e instanceof Error ? e.message : 'failed to load tags';
 			})
 			.finally(() => {
+				if (tagsRequest !== request) return; // stale response
 				tagsLoading = false;
 			});
 	});
@@ -348,26 +364,23 @@
 							<span class="rating-pill rating-{currentRating}">{currentRating}</span>
 						{/if}
 					</h3>
-					{#if tagsLoading}
-						<p class="tags-status" role="status">Loading…</p>
-					{:else if tagsError}
-						<p class="tags-status" role="status">{tagsError}</p>
-					{:else if currentTags && currentTags.tags.length > 0}
-						<ul class="tag-list">
-							{#each visibleTags as tag}
-								<li class="tag">{tag.name}</li>
-							{/each}
-							{#if hiddenTagCount > 0 && !tagsExpanded}
-								<li>
-									<button class="more-tags" type="button" onclick={() => (tagsExpanded = true)}>
-										and {hiddenTagCount} more
-									</button>
-								</li>
-							{/if}
-						</ul>
-					{:else}
-						<p class="tags-status" role="status">No tags for this image.</p>
-					{/if}
+					<div class="tags-body">
+						<p class="tags-status" role="status">{tagsStatus}</p>
+						{#if !tagsStatus}
+							<ul class="tag-list">
+								{#each visibleTags as tag}
+									<li class="tag">{tag.name}</li>
+								{/each}
+								{#if hiddenTagCount > 0 && !tagsExpanded}
+									<li>
+										<button class="more-tags" type="button" onclick={() => (tagsExpanded = true)}>
+											and {hiddenTagCount} more
+										</button>
+									</li>
+								{/if}
+							</ul>
+						{/if}
+					</div>
 				</div>
 				{/if}
 
@@ -729,7 +742,7 @@
 	.rating-explicit {
 		/* #e76e55 clears 4.5:1 AA contrast over the tinted dark card (#e0533a was ~4:1) */
 		color: #e76e55;
-		background: rgba(224, 83, 58, 0.12);
+		background: rgba(231, 110, 85, 0.12);
 	}
 
 	.tags-status {
@@ -739,10 +752,10 @@
 		color: var(--fg-subtle);
 	}
 
-	/* Reserve ~two rows of tag chips so Loading→tags doesn't shift the buttons below */
-	.tags-status,
-	.tag-list {
-		min-height: 54px;
+	/* Reserve ~two rows of tag chips so Loading→tags doesn't shift the buttons below.
+	   On the wrapper, not the status <p>: the empty status must not add height. */
+	.tags-body {
+		min-height: 58px;
 	}
 
 	.tag-list {

--- a/src/lib/components/PhotoModal.svelte
+++ b/src/lib/components/PhotoModal.svelte
@@ -77,8 +77,13 @@
 		tagsExpanded = false;
 	});
 
-	onMount(() => {
-		if (!e621Enabled) return;
+	// Fetch once e621Enabled becomes true — auth (uwu/ageVerified) resolves
+	// asynchronously after mount, so an onMount check would skip the fetch
+	// when the modal is opened via a direct post URL.
+	let tagsRequested = false;
+	$effect(() => {
+		if (!e621Enabled || tagsRequested) return;
+		tagsRequested = true;
 		tagsLoading = true;
 		getPostTags(post.author.did, rkey)
 			.then((r) => {
@@ -328,7 +333,7 @@
 				<div class="tags-section">
 					<h3>
 						e621 Tags
-						{#if currentTags}
+						{#if currentTags?.rating}
 							<span class="rating-pill rating-{currentTags.rating}">{currentTags.rating}</span>
 						{/if}
 					</h3>

--- a/src/lib/components/PhotoModal.svelte
+++ b/src/lib/components/PhotoModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import type { PhotoPost } from '$lib/api/bluesky.js';
-	import { getPostTags, type EntailImageTags } from '$lib/api/entail.js';
+	import { getPostTags, type EntailImageTags, type EntailRating } from '$lib/api/entail.js';
 	import { goto } from '$app/navigation';
 	import {
 		authState,
@@ -71,6 +71,10 @@
 	const hiddenTagCount = $derived(
 		currentTags ? Math.max(0, currentTags.tags.length - TAG_LIMIT) : 0
 	);
+	// Only render the pill for known ratings — the value comes from a third-party
+	// API and is interpolated into a class name.
+	const KNOWN_RATINGS: EntailRating[] = ['safe', 'questionable', 'explicit'];
+	const currentRating = $derived(KNOWN_RATINGS.find((r) => r === currentTags?.rating) ?? null);
 
 	$effect(() => {
 		void image.cid;
@@ -80,10 +84,17 @@
 	// Fetch once e621Enabled becomes true — auth (uwu/ageVerified) resolves
 	// asynchronously after mount, so an onMount check would skip the fetch
 	// when the modal is opened via a direct post URL.
-	let tagsRequested = false;
+	// Plain (non-$state) on purpose: the guard must not be a tracked dependency.
+	let tagsRequestedFor: string | null = null;
 	$effect(() => {
-		if (!e621Enabled || tagsRequested) return;
-		tagsRequested = true;
+		if (!e621Enabled) {
+			// Allow a refetch after logout→login or a failed request.
+			tagsRequestedFor = null;
+			tagsError = null;
+			return;
+		}
+		if (tagsRequestedFor === rkey) return;
+		tagsRequestedFor = rkey;
 		tagsLoading = true;
 		getPostTags(post.author.did, rkey)
 			.then((r) => {
@@ -333,14 +344,14 @@
 				<div class="tags-section">
 					<h3>
 						e621 Tags
-						{#if currentTags?.rating}
-							<span class="rating-pill rating-{currentTags.rating}">{currentTags.rating}</span>
+						{#if currentRating}
+							<span class="rating-pill rating-{currentRating}">{currentRating}</span>
 						{/if}
 					</h3>
 					{#if tagsLoading}
-						<p class="tags-status">Loading…</p>
+						<p class="tags-status" role="status">Loading…</p>
 					{:else if tagsError}
-						<p class="tags-status">{tagsError}</p>
+						<p class="tags-status" role="status">{tagsError}</p>
 					{:else if currentTags && currentTags.tags.length > 0}
 						<ul class="tag-list">
 							{#each visibleTags as tag}
@@ -355,7 +366,7 @@
 							{/if}
 						</ul>
 					{:else}
-						<p class="tags-status">No tags for this image.</p>
+						<p class="tags-status" role="status">No tags for this image.</p>
 					{/if}
 				</div>
 				{/if}
@@ -716,7 +727,8 @@
 	}
 
 	.rating-explicit {
-		color: #e0533a;
+		/* #e76e55 clears 4.5:1 AA contrast over the tinted dark card (#e0533a was ~4:1) */
+		color: #e76e55;
 		background: rgba(224, 83, 58, 0.12);
 	}
 
@@ -727,12 +739,19 @@
 		color: var(--fg-subtle);
 	}
 
+	/* Reserve ~two rows of tag chips so Loading→tags doesn't shift the buttons below */
+	.tags-status,
+	.tag-list {
+		min-height: 54px;
+	}
+
 	.tag-list {
 		list-style: none;
 		padding: 0;
 		margin: 0;
 		display: flex;
 		flex-wrap: wrap;
+		align-content: flex-start;
 		gap: 6px;
 	}
 

--- a/src/routes/mosaic/[handle]/+page.svelte
+++ b/src/routes/mosaic/[handle]/+page.svelte
@@ -198,7 +198,7 @@
 				maxDepth: Math.min($settings.crawlDepth, 5),
 				accountsPerLevel: Math.min($settings.accountsPerLevel, 200),
 				postsPerAccount: Math.min($settings.postsPerAccount, 500)
-			})) {
+			}, profile ?? undefined)) {
 				if (event.type === 'photos') {
 					const newPosts = event.posts.filter((p: PhotoPost) => !seenUris.has(p.uri));
 					for (const p of newPosts) seenUris.add(p.uri);


### PR DESCRIPTION
## Summary

Three fixes in the photo modal / crawler, stacked on #20:

**e621 tags now work on mobile** (`PhotoModal.svelte`)
- The tag fetch lived in `onMount` behind a one-shot `e621Enabled` check, but auth (FurryList + 18+ verification) resolves asynchronously after mount — so modals opened via direct post URLs (the normal mobile pattern) never fetched. The fetch is now a reactive `$effect` that fires when the gate becomes true, with an identity-token guard so stale responses (late rejections, superseded requests) can never clobber fresh state.
- Rating pill only renders for known ratings (`safe`/`questionable`/`explicit`) — no more empty chip when the API returns `rating: null`, and third-party strings can't reach the class attribute.
- Polish from review: persistent `role="status"` live region for the async states, reserved space so the CTA buttons don't jump when tags land (≤4px), AA contrast for the explicit pill (#e76e55 + matching fill).

**Discovery chains always include the root artist** (`crawler.ts`, mosaic page)
- Phone keyboards auto-capitalize search input; the API accepts any handle casing but returns canonical lowercase, so the crawler's strict handle comparison never matched a self-authored post, the root profile silently failed to build, and every chain started one hop late. The crawl is now seeded with the page's already-fetched canonical profile (also fixing repost-only curator accounts), `visited` uses the canonical handle (no more self-rediscovery), and the fallback comparison is case-insensitive.

Also gitignores `.ship/` (review artifacts).

## Testing

- `npm run check`: 0 errors; `npm run build`: succeeds.
- e621 flows driven end-to-end in Chromium at mobile viewport with network-mocked auth (direct-URL open with delayed auth → tags appear; `rating: null` → "No tags for this image.", zero pills; unknown rating → no pill; logged out → no section, no errors).
- Crawler fix verified with the reporter's exact recipe (depth 2, 10 accounts/level, 5 posts/account, MintCashew → beb's post `3mpwuupuyfc2l`): capitalized URL previously gave `@rogue0x1 → @itsbebhere`, now gives `@mintcashew → @rogue0x1 → @itsbebhere`; lowercase crawl unchanged (no regression). Confirmed working on a real device.
- No automated regression tests: the repo has no test harness — tracked in #18, which now carries the recommended race-case test spec for this logic.